### PR TITLE
release: bump version to 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：GO  
 GO version：1.22.5+  
-Tags：v1.3.3
+Tags：v1.3.4
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/api/sdk_version.go
+++ b/com/alipay/api/sdk_version.go
@@ -1,6 +1,6 @@
 package defaultAlipayClient
 
-const SDKVersion = "1.3.3"
+const SDKVersion = "1.3.4"
 
 func sdkUserAgent() string {
 	return "global-open-sdk-go/" + SDKVersion


### PR DESCRIPTION
## Summary
- bump Go SDK version from 1.3.3 to 1.3.4
- update the release tag reference in README

## Verification
- `go test ./com/alipay/api/...`
- `go vet ./com/alipay/api/...`
- `go mod verify`
- `gofmt` check
- verified User-Agent source `global-open-sdk-go/1.3.4`

## Known repository issue
- `go test ./...` and `go vet ./...` remain blocked by multiple existing `main()` functions in `com/alipay/example`; this release does not modify that example layout.