### PR TITLE
release: bump version to 1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：GO  
 GO version：1.22.5+  
-Tags：v1.3.4
+Tags：v1.3.5
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/api/sdk_version.go
+++ b/com/alipay/api/sdk_version.go
@@ -1,6 +1,6 @@
 package defaultAlipayClient
 
-const SDKVersion = "1.3.4"
+const SDKVersion = "1.3.5"
 
 func sdkUserAgent() string {
 	return "global-open-sdk-go/" + SDKVersion


### PR DESCRIPTION
## Summary

- Bump github.com/alipay/global-open-sdk-go from 1.3.4 to 1.3.5.
- Update the README tag example.

## Verification

- go mod verify passed.
- gofmt and case-fold collision checks passed.
- SDK-only go test and go vet passed.
- Full ./... checks remain blocked by the existing example package containing multiple main functions; the same failure is present in the 1.3.4 baseline.
- SDK version and User-Agent source report 1.3.5.