### PR TITLE
Update APIs and prepare Go SDK 1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：GO  
 GO version：1.22.5+  
-Tags：v1.3.5
+Tags：v1.3.6
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/api/model/AuthorizationControl.go
+++ b/com/alipay/api/model/AuthorizationControl.go
@@ -6,6 +6,7 @@ type AuthorizationControl struct {
 	AllowedMerchantCategoryList []string          `json:"allowedMerchantCategoryList,omitempty"`
 	AllowedAuthTimes            int32             `json:"allowedAuthTimes,omitempty"`
 	AllowedCurrencies           []string          `json:"allowedCurrencies,omitempty"`
+	PaymentPreferenceCurrencies []string          `json:"paymentPreferenceCurrencies,omitempty"`
 	CardLimitDetail             *CardLimitDetail  `json:"cardLimitDetail,omitempty"`
 	CardLimitInfo               *CardLimitInfo    `json:"cardLimitInfo,omitempty"`
 	RefundPreference            *RefundPreference `json:"refundPreference,omitempty"`

--- a/com/alipay/api/model/BillingSubscriptionStatusChange.go
+++ b/com/alipay/api/model/BillingSubscriptionStatusChange.go
@@ -1,0 +1,5 @@
+package model
+
+type BillingSubscriptionStatusChange struct {
+	Action string `json:"action,omitempty"`
+}

--- a/com/alipay/api/model/CardDetail.go
+++ b/com/alipay/api/model/CardDetail.go
@@ -1,0 +1,16 @@
+package model
+
+type CardDetail struct {
+	AssetId              string                `json:"assetId,omitempty"`
+	CardNickName         string                `json:"cardNickName,omitempty"`
+	CardStatus           string                `json:"cardStatus,omitempty"`
+	MaskedCardNo         string                `json:"maskedCardNo,omitempty"`
+	CardBrand            string                `json:"cardBrand,omitempty"`
+	CreatedTime          string                `json:"createdTime,omitempty"`
+	UpdatedTime          string                `json:"updatedTime,omitempty"`
+	Purpose              string                `json:"purpose,omitempty"`
+	Note                 string                `json:"note,omitempty"`
+	Metadata             map[string]string     `json:"metadata,omitempty"`
+	AuthorizationControl *AuthorizationControl `json:"authorizationControl,omitempty"`
+	Cardholderinfo       *CardholderInfo       `json:"cardholderinfo,omitempty"`
+}

--- a/com/alipay/api/model/FundsType.go
+++ b/com/alipay/api/model/FundsType.go
@@ -1,0 +1,7 @@
+package model
+
+type FundsType string
+
+const (
+	FundsType_COLLATERAL FundsType = "COLLATERAL"
+)

--- a/com/alipay/api/model/PaymentMethodScope.go
+++ b/com/alipay/api/model/PaymentMethodScope.go
@@ -1,0 +1,8 @@
+package model
+
+type PaymentMethodScope string
+
+const (
+	PaymentMethodScope_ALL  PaymentMethodScope = "ALL"
+	PaymentMethodScope_CARD PaymentMethodScope = "CARD"
+)

--- a/com/alipay/api/model/ReleaseType.go
+++ b/com/alipay/api/model/ReleaseType.go
@@ -1,0 +1,8 @@
+package model
+
+type ReleaseType string
+
+const (
+	ReleaseType_FIXED_TIME    ReleaseType = "FIXED_TIME"
+	ReleaseType_INTERVAL_TIME ReleaseType = "INTERVAL_TIME"
+)

--- a/com/alipay/api/model/ReserveRule.go
+++ b/com/alipay/api/model/ReserveRule.go
@@ -1,0 +1,16 @@
+package model
+
+type ReserveRule struct {
+	RuleId             string             `json:"ruleId,omitempty"`
+	MerchantId         string             `json:"merchantId,omitempty"`
+	FundsType          FundsType          `json:"fundsType,omitempty"`
+	TakeType           TakeType           `json:"takeType,omitempty"`
+	PaymentMethodScope PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32              `json:"ratio,omitempty"`
+	ReleaseType        ReleaseType        `json:"releaseType,omitempty"`
+	ReleaseTime        string             `json:"releaseTime,omitempty"`
+	RetentionTime      int32              `json:"retentionTime,omitempty"`
+	RuleStatus         RuleStatus         `json:"ruleStatus,omitempty"`
+	CreateTime         string             `json:"createTime,omitempty"`
+	UpdateTime         string             `json:"updateTime,omitempty"`
+}

--- a/com/alipay/api/model/RuleStatus.go
+++ b/com/alipay/api/model/RuleStatus.go
@@ -1,0 +1,8 @@
+package model
+
+type RuleStatus string
+
+const (
+	RuleStatus_ACTIVE   RuleStatus = "ACTIVE"
+	RuleStatus_DISABLED RuleStatus = "DISABLED"
+)

--- a/com/alipay/api/model/TakeType.go
+++ b/com/alipay/api/model/TakeType.go
@@ -1,0 +1,7 @@
+package model
+
+type TakeType string
+
+const (
+	TakeType_ROLLING TakeType = "ROLLING"
+)

--- a/com/alipay/api/model/TaxCalculatedAddress.go
+++ b/com/alipay/api/model/TaxCalculatedAddress.go
@@ -1,0 +1,12 @@
+package model
+
+type TaxCalculatedAddress struct {
+	Country    string `json:"country,omitempty"`
+	Region     string `json:"region,omitempty"`
+	County     string `json:"county,omitempty"`
+	City       string `json:"city,omitempty"`
+	District   string `json:"district,omitempty"`
+	Line1      string `json:"line1,omitempty"`
+	Line2      string `json:"line2,omitempty"`
+	PostalCode string `json:"postalCode,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedBusinessDetails.go
+++ b/com/alipay/api/model/TaxCalculatedBusinessDetails.go
@@ -1,0 +1,5 @@
+package model
+
+type TaxCalculatedBusinessDetails struct {
+	Address *TaxCalculatedAddress `json:"address,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedCustomerDetails.go
+++ b/com/alipay/api/model/TaxCalculatedCustomerDetails.go
@@ -1,0 +1,9 @@
+package model
+
+type TaxCalculatedCustomerDetails struct {
+	BusinessDetails *TaxCalculatedBusinessDetails `json:"businessDetails,omitempty"`
+	ShippingAddress *TaxCalculatedAddress         `json:"shippingAddress,omitempty"`
+	BillingAddress  *TaxCalculatedAddress         `json:"billingAddress,omitempty"`
+	TaxIds          []*TaxCalculatedTaxId         `json:"taxIds,omitempty"`
+	TaxExemptions   []*TaxCalculatedExemption     `json:"taxExemptions,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedExemption.go
+++ b/com/alipay/api/model/TaxCalculatedExemption.go
@@ -1,0 +1,7 @@
+package model
+
+type TaxCalculatedExemption struct {
+	CertificateNumber string                              `json:"certificateNumber,omitempty"`
+	ExemptionType     string                              `json:"exemptionType,omitempty"`
+	Jurisdiction      *TaxCalculatedExemptionJurisdiction `json:"jurisdiction,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedExemptionJurisdiction.go
+++ b/com/alipay/api/model/TaxCalculatedExemptionJurisdiction.go
@@ -1,0 +1,8 @@
+package model
+
+type TaxCalculatedExemptionJurisdiction struct {
+	Country       string `json:"country,omitempty"`
+	Region        string `json:"region,omitempty"`
+	City          string `json:"city,omitempty"`
+	EffectiveFrom string `json:"effectiveFrom,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedLineItem.go
+++ b/com/alipay/api/model/TaxCalculatedLineItem.go
@@ -2,7 +2,6 @@ package model
 
 type TaxCalculatedLineItem struct {
 	GoodsReferenceId string          `json:"goodsReferenceId,omitempty"`
-	UnitAmount       string          `json:"unitAmount,omitempty"`
 	Amount           string          `json:"amount,omitempty"`
 	Quantity         int32           `json:"quantity,omitempty"`
 	TaxCode          string          `json:"taxCode,omitempty"`

--- a/com/alipay/api/model/TaxCalculatedShipFromDetails.go
+++ b/com/alipay/api/model/TaxCalculatedShipFromDetails.go
@@ -1,0 +1,5 @@
+package model
+
+type TaxCalculatedShipFromDetails struct {
+	Address *TaxCalculatedAddress `json:"address,omitempty"`
+}

--- a/com/alipay/api/model/TaxCalculatedTaxId.go
+++ b/com/alipay/api/model/TaxCalculatedTaxId.go
@@ -1,6 +1,6 @@
 package model
 
-type TaxId struct {
+type TaxCalculatedTaxId struct {
 	Value   string `json:"value,omitempty"`
 	Country string `json:"country,omitempty"`
 	Region  string `json:"region,omitempty"`

--- a/com/alipay/api/model/TaxCalculationLineItem.go
+++ b/com/alipay/api/model/TaxCalculationLineItem.go
@@ -2,7 +2,7 @@ package model
 
 type TaxCalculationLineItem struct {
 	GoodsReferenceId string `json:"goodsReferenceId,omitempty"`
-	UnitAmount       string `json:"unitAmount,omitempty"`
+	Amount           string `json:"amount,omitempty"`
 	Quantity         int32  `json:"quantity,omitempty"`
 	TaxCode          string `json:"taxCode,omitempty"`
 	ProductId        string `json:"productId,omitempty"`

--- a/com/alipay/api/model/TaxCustomerDetails.go
+++ b/com/alipay/api/model/TaxCustomerDetails.go
@@ -1,9 +1,9 @@
 package model
 
 type TaxCustomerDetails struct {
-	Name            string              `json:"name,omitempty"`
 	BusinessDetails *TaxBusinessDetails `json:"businessDetails,omitempty"`
 	ShippingAddress *TaxAddress         `json:"shippingAddress,omitempty"`
 	BillingAddress  *TaxAddress         `json:"billingAddress,omitempty"`
 	TaxIds          []*TaxId            `json:"taxIds,omitempty"`
+	TaxExemptions   []*TaxExemption     `json:"taxExemptions,omitempty"`
 }

--- a/com/alipay/api/model/TaxExemption.go
+++ b/com/alipay/api/model/TaxExemption.go
@@ -1,0 +1,7 @@
+package model
+
+type TaxExemption struct {
+	CertificateNumber string                    `json:"certificateNumber,omitempty"`
+	ExemptionType     string                    `json:"exemptionType,omitempty"`
+	Jurisdiction      *TaxExemptionJurisdiction `json:"jurisdiction,omitempty"`
+}

--- a/com/alipay/api/model/TaxExemptionJurisdiction.go
+++ b/com/alipay/api/model/TaxExemptionJurisdiction.go
@@ -1,0 +1,8 @@
+package model
+
+type TaxExemptionJurisdiction struct {
+	Country       string `json:"country,omitempty"`
+	Region        string `json:"region,omitempty"`
+	City          string `json:"city,omitempty"`
+	EffectiveFrom string `json:"effectiveFrom,omitempty"`
+}

--- a/com/alipay/api/request/billing/AlipayBillingSubscriptionUpdateRequest.go
+++ b/com/alipay/api/request/billing/AlipayBillingSubscriptionUpdateRequest.go
@@ -12,6 +12,7 @@ type AlipayBillingSubscriptionUpdateRequest struct {
 	ProrationBehavior       string                                        `json:"prorationBehavior,omitempty"`
 	ResetBillingCycleAnchor bool                                          `json:"resetBillingCycleAnchor,omitempty"`
 	TrialSettings           *model.BillingTrialSettings                   `json:"trialSettings,omitempty"`
+	StatusChange            *model.BillingSubscriptionStatusChange        `json:"statusChange,omitempty"`
 	CancelAtPeriodEnd       bool                                          `json:"cancelAtPeriodEnd,omitempty"`
 	CancelAt                string                                        `json:"cancelAt,omitempty"`
 	CancellationDetails     *model.BillingSubscriptionCancellationDetails `json:"cancellationDetails,omitempty"`

--- a/com/alipay/api/request/pay/AlipayCancelRuleRequest.go
+++ b/com/alipay/api/request/pay/AlipayCancelRuleRequest.go
@@ -1,0 +1,20 @@
+package pay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/request"
+	responsePay "github.com/alipay/global-open-sdk-go/com/alipay/api/response/pay"
+)
+
+type AlipayCancelRuleRequest struct {
+	RuleId string `json:"ruleId,omitempty"`
+}
+
+func NewAlipayCancelRuleRequest() (*request.AlipayRequest, *AlipayCancelRuleRequest) {
+	alipayCancelRuleRequest := &AlipayCancelRuleRequest{}
+	alipayRequest := request.NewAlipayRequest(alipayCancelRuleRequest, "/ams/api/v1/payments/reserve/cancelRule", &responsePay.AlipayCancelRuleResponse{})
+	return alipayRequest, alipayCancelRuleRequest
+}
+
+func (alipayCancelRuleRequest *AlipayCancelRuleRequest) NewRequest() *request.AlipayRequest {
+	return request.NewAlipayRequest(&alipayCancelRuleRequest, "/ams/api/v1/payments/reserve/cancelRule", &responsePay.AlipayCancelRuleResponse{})
+}

--- a/com/alipay/api/request/pay/AlipayCreateRuleRequest.go
+++ b/com/alipay/api/request/pay/AlipayCreateRuleRequest.go
@@ -1,0 +1,27 @@
+package pay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/request"
+	responsePay "github.com/alipay/global-open-sdk-go/com/alipay/api/response/pay"
+)
+
+type AlipayCreateRuleRequest struct {
+	FundsType          model.FundsType          `json:"fundsType,omitempty"`
+	TakeType           model.TakeType           `json:"takeType,omitempty"`
+	PaymentMethodScope model.PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32                    `json:"ratio,omitempty"`
+	ReleaseType        model.ReleaseType        `json:"releaseType,omitempty"`
+	ReleaseTime        string                   `json:"releaseTime,omitempty"`
+	RetentionTime      int32                    `json:"retentionTime,omitempty"`
+}
+
+func NewAlipayCreateRuleRequest() (*request.AlipayRequest, *AlipayCreateRuleRequest) {
+	alipayCreateRuleRequest := &AlipayCreateRuleRequest{}
+	alipayRequest := request.NewAlipayRequest(alipayCreateRuleRequest, "/ams/api/v1/payments/reserve/createRule", &responsePay.AlipayCreateRuleResponse{})
+	return alipayRequest, alipayCreateRuleRequest
+}
+
+func (alipayCreateRuleRequest *AlipayCreateRuleRequest) NewRequest() *request.AlipayRequest {
+	return request.NewAlipayRequest(&alipayCreateRuleRequest, "/ams/api/v1/payments/reserve/createRule", &responsePay.AlipayCreateRuleResponse{})
+}

--- a/com/alipay/api/request/pay/AlipayInquireRuleListRequest.go
+++ b/com/alipay/api/request/pay/AlipayInquireRuleListRequest.go
@@ -1,0 +1,26 @@
+package pay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/request"
+	responsePay "github.com/alipay/global-open-sdk-go/com/alipay/api/response/pay"
+)
+
+type AlipayInquireRuleListRequest struct {
+	FundsType     model.FundsType   `json:"fundsType,omitempty"`
+	TakeType      model.TakeType    `json:"takeType,omitempty"`
+	ReleaseType   model.ReleaseType `json:"releaseType,omitempty"`
+	Limit         int32             `json:"limit,omitempty"`
+	StartingAfter string            `json:"startingAfter,omitempty"`
+	EndingBefore  string            `json:"endingBefore,omitempty"`
+}
+
+func NewAlipayInquireRuleListRequest() (*request.AlipayRequest, *AlipayInquireRuleListRequest) {
+	alipayInquireRuleListRequest := &AlipayInquireRuleListRequest{}
+	alipayRequest := request.NewAlipayRequest(alipayInquireRuleListRequest, "/ams/api/v1/payments/reserve/inquireRuleList", &responsePay.AlipayInquireRuleListResponse{})
+	return alipayRequest, alipayInquireRuleListRequest
+}
+
+func (alipayInquireRuleListRequest *AlipayInquireRuleListRequest) NewRequest() *request.AlipayRequest {
+	return request.NewAlipayRequest(&alipayInquireRuleListRequest, "/ams/api/v1/payments/reserve/inquireRuleList", &responsePay.AlipayInquireRuleListResponse{})
+}

--- a/com/alipay/api/request/pay/AlipayUpdateRuleRequest.go
+++ b/com/alipay/api/request/pay/AlipayUpdateRuleRequest.go
@@ -1,0 +1,26 @@
+package pay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/request"
+	responsePay "github.com/alipay/global-open-sdk-go/com/alipay/api/response/pay"
+)
+
+type AlipayUpdateRuleRequest struct {
+	RuleId             string                   `json:"ruleId,omitempty"`
+	PaymentMethodScope model.PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32                    `json:"ratio,omitempty"`
+	ReleaseTime        string                   `json:"releaseTime,omitempty"`
+	RetentionTime      int32                    `json:"retentionTime,omitempty"`
+	RuleStatus         model.RuleStatus         `json:"ruleStatus,omitempty"`
+}
+
+func NewAlipayUpdateRuleRequest() (*request.AlipayRequest, *AlipayUpdateRuleRequest) {
+	alipayUpdateRuleRequest := &AlipayUpdateRuleRequest{}
+	alipayRequest := request.NewAlipayRequest(alipayUpdateRuleRequest, "/ams/api/v1/payments/reserve/updateRule", &responsePay.AlipayUpdateRuleResponse{})
+	return alipayRequest, alipayUpdateRuleRequest
+}
+
+func (alipayUpdateRuleRequest *AlipayUpdateRuleRequest) NewRequest() *request.AlipayRequest {
+	return request.NewAlipayRequest(&alipayUpdateRuleRequest, "/ams/api/v1/payments/reserve/updateRule", &responsePay.AlipayUpdateRuleResponse{})
+}

--- a/com/alipay/api/response/aba/AlipayInquireCardSensitiveInfoResponse.go
+++ b/com/alipay/api/response/aba/AlipayInquireCardSensitiveInfoResponse.go
@@ -7,10 +7,11 @@ import (
 
 type AlipayInquireCardSensitiveInfoResponse struct {
 	response.AlipayResponse
-	Result       *model.Result `json:"result,omitempty"`
-	AssetId      string        `json:"assetId,omitempty"`
-	Cvv          string        `json:"cvv,omitempty"`
-	CardNo       string        `json:"cardNo,omitempty"`
-	ExpiredMonth string        `json:"expiredMonth,omitempty"`
-	ExpiredYear  string        `json:"expiredYear,omitempty"`
+	Result       *model.Result     `json:"result,omitempty"`
+	AssetId      string            `json:"assetId,omitempty"`
+	Cvv          string            `json:"cvv,omitempty"`
+	CardNo       string            `json:"cardNo,omitempty"`
+	ExpiredMonth string            `json:"expiredMonth,omitempty"`
+	ExpiredYear  string            `json:"expiredYear,omitempty"`
+	CardDetail   *model.CardDetail `json:"cardDetail,omitempty"`
 }

--- a/com/alipay/api/response/billing/AlipayInvoiceExportResponse.go
+++ b/com/alipay/api/response/billing/AlipayInvoiceExportResponse.go
@@ -13,4 +13,5 @@ type AlipayInvoiceExportResponse struct {
 	FileUrl    string        `json:"fileUrl,omitempty"`
 	FileSize   int64         `json:"fileSize,omitempty"`
 	FileName   string        `json:"fileName,omitempty"`
+	Mode       string        `json:"mode,omitempty"`
 }

--- a/com/alipay/api/response/billing/AlipayReceiptExportResponse.go
+++ b/com/alipay/api/response/billing/AlipayReceiptExportResponse.go
@@ -13,4 +13,5 @@ type AlipayReceiptExportResponse struct {
 	FileUrl    string        `json:"fileUrl,omitempty"`
 	FileSize   int64         `json:"fileSize,omitempty"`
 	FileName   string        `json:"fileName,omitempty"`
+	Mode       string        `json:"mode,omitempty"`
 }

--- a/com/alipay/api/response/billing/AlipayReceiptInquireListResponse.go
+++ b/com/alipay/api/response/billing/AlipayReceiptInquireListResponse.go
@@ -7,9 +7,10 @@ import (
 
 type AlipayReceiptInquireListResponse struct {
 	response.AlipayResponse
-	Result     *model.Result    `json:"result,omitempty"`
-	Receipts   []*model.Receipt `json:"receipts,omitempty"`
-	Total      int32            `json:"total,omitempty"`
-	HasMore    bool             `json:"hasMore,omitempty"`
-	NextCursor string           `json:"nextCursor,omitempty"`
+	Result         *model.Result    `json:"result,omitempty"`
+	Receipts       []*model.Receipt `json:"receipts,omitempty"`
+	Total          int32            `json:"total,omitempty"`
+	HasMore        bool             `json:"hasMore,omitempty"`
+	NextCursor     string           `json:"nextCursor,omitempty"`
+	PreviousCursor string           `json:"previousCursor,omitempty"`
 }

--- a/com/alipay/api/response/billing/AlipayTaxCalculateResponse.go
+++ b/com/alipay/api/response/billing/AlipayTaxCalculateResponse.go
@@ -7,15 +7,16 @@ import (
 
 type AlipayTaxCalculateResponse struct {
 	response.AlipayResponse
-	Result             *model.Result                    `json:"result,omitempty"`
-	TaxCalculationId   string                           `json:"taxCalculationId,omitempty"`
-	Currency           string                           `json:"currency,omitempty"`
-	TotalAmount        string                           `json:"totalAmount,omitempty"`
-	ExclusiveTaxAmount string                           `json:"exclusiveTaxAmount,omitempty"`
-	InclusiveTaxAmount string                           `json:"inclusiveTaxAmount,omitempty"`
-	LineItems          []*model.TaxCalculatedLineItem   `json:"lineItems,omitempty"`
-	TaxBreakdown       []*model.TaxBreakdown            `json:"taxBreakdown,omitempty"`
-	ExpireAt           string                           `json:"expireAt,omitempty"`
-	TaxDate            string                           `json:"taxDate,omitempty"`
-	ShippingCost       *model.TaxCalculatedShippingCost `json:"shippingCost,omitempty"`
+	Result             *model.Result                       `json:"result,omitempty"`
+	TaxCalculationId   string                              `json:"taxCalculationId,omitempty"`
+	Currency           string                              `json:"currency,omitempty"`
+	TotalAmount        string                              `json:"totalAmount,omitempty"`
+	ExclusiveTaxAmount string                              `json:"exclusiveTaxAmount,omitempty"`
+	InclusiveTaxAmount string                              `json:"inclusiveTaxAmount,omitempty"`
+	LineItems          []*model.TaxCalculatedLineItem      `json:"lineItems,omitempty"`
+	TaxBreakdown       []*model.TaxBreakdown               `json:"taxBreakdown,omitempty"`
+	ExpireAt           string                              `json:"expireAt,omitempty"`
+	TaxDate            string                              `json:"taxDate,omitempty"`
+	ShippingCost       *model.TaxCalculatedShippingCost    `json:"shippingCost,omitempty"`
+	CustomerDetails    *model.TaxCalculatedCustomerDetails `json:"customerDetails,omitempty"`
 }

--- a/com/alipay/api/response/billing/AlipayTaxInquireCalculationResponse.go
+++ b/com/alipay/api/response/billing/AlipayTaxInquireCalculationResponse.go
@@ -7,15 +7,17 @@ import (
 
 type AlipayTaxInquireCalculationResponse struct {
 	response.AlipayResponse
-	Result             *model.Result                    `json:"result,omitempty"`
-	TaxCalculationId   string                           `json:"taxCalculationId,omitempty"`
-	Currency           string                           `json:"currency,omitempty"`
-	TotalAmount        string                           `json:"totalAmount,omitempty"`
-	ExclusiveTaxAmount string                           `json:"exclusiveTaxAmount,omitempty"`
-	InclusiveTaxAmount string                           `json:"inclusiveTaxAmount,omitempty"`
-	LineItems          []*model.TaxCalculatedLineItem   `json:"lineItems,omitempty"`
-	TaxBreakdown       []*model.TaxBreakdown            `json:"taxBreakdown,omitempty"`
-	ExpireAt           string                           `json:"expireAt,omitempty"`
-	TaxDate            string                           `json:"taxDate,omitempty"`
-	ShippingCost       *model.TaxCalculatedShippingCost `json:"shippingCost,omitempty"`
+	Result             *model.Result                       `json:"result,omitempty"`
+	TaxCalculationId   string                              `json:"taxCalculationId,omitempty"`
+	Currency           string                              `json:"currency,omitempty"`
+	CustomerDetails    *model.TaxCalculatedCustomerDetails `json:"customerDetails,omitempty"`
+	ShipFromDetails    *model.TaxCalculatedShipFromDetails `json:"shipFromDetails,omitempty"`
+	TotalAmount        string                              `json:"totalAmount,omitempty"`
+	ExclusiveTaxAmount string                              `json:"exclusiveTaxAmount,omitempty"`
+	InclusiveTaxAmount string                              `json:"inclusiveTaxAmount,omitempty"`
+	LineItems          []*model.TaxCalculatedLineItem      `json:"lineItems,omitempty"`
+	TaxBreakdown       []*model.TaxBreakdown               `json:"taxBreakdown,omitempty"`
+	ExpireAt           string                              `json:"expireAt,omitempty"`
+	TaxDate            string                              `json:"taxDate,omitempty"`
+	ShippingCost       *model.TaxCalculatedShippingCost    `json:"shippingCost,omitempty"`
 }

--- a/com/alipay/api/response/pay/AlipayCancelRuleResponse.go
+++ b/com/alipay/api/response/pay/AlipayCancelRuleResponse.go
@@ -1,0 +1,23 @@
+package responsePay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/response"
+)
+
+type AlipayCancelRuleResponse struct {
+	response.AlipayResponse
+	Result             *model.Result            `json:"result,omitempty"`
+	RuleId             string                   `json:"ruleId,omitempty"`
+	MerchantId         string                   `json:"merchantId,omitempty"`
+	FundsType          model.FundsType          `json:"fundsType,omitempty"`
+	TakeType           model.TakeType           `json:"takeType,omitempty"`
+	PaymentMethodScope model.PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32                    `json:"ratio,omitempty"`
+	ReleaseType        model.ReleaseType        `json:"releaseType,omitempty"`
+	ReleaseTime        string                   `json:"releaseTime,omitempty"`
+	RetentionTime      int32                    `json:"retentionTime,omitempty"`
+	RuleStatus         model.RuleStatus         `json:"ruleStatus,omitempty"`
+	CreateTime         string                   `json:"createTime,omitempty"`
+	UpdateTime         string                   `json:"updateTime,omitempty"`
+}

--- a/com/alipay/api/response/pay/AlipayCreateRuleResponse.go
+++ b/com/alipay/api/response/pay/AlipayCreateRuleResponse.go
@@ -1,0 +1,23 @@
+package responsePay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/response"
+)
+
+type AlipayCreateRuleResponse struct {
+	response.AlipayResponse
+	Result             *model.Result            `json:"result,omitempty"`
+	RuleId             string                   `json:"ruleId,omitempty"`
+	MerchantId         string                   `json:"merchantId,omitempty"`
+	FundsType          model.FundsType          `json:"fundsType,omitempty"`
+	TakeType           model.TakeType           `json:"takeType,omitempty"`
+	PaymentMethodScope model.PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32                    `json:"ratio,omitempty"`
+	ReleaseType        model.ReleaseType        `json:"releaseType,omitempty"`
+	ReleaseTime        string                   `json:"releaseTime,omitempty"`
+	RetentionTime      int32                    `json:"retentionTime,omitempty"`
+	RuleStatus         model.RuleStatus         `json:"ruleStatus,omitempty"`
+	CreateTime         string                   `json:"createTime,omitempty"`
+	UpdateTime         string                   `json:"updateTime,omitempty"`
+}

--- a/com/alipay/api/response/pay/AlipayInquireRuleListResponse.go
+++ b/com/alipay/api/response/pay/AlipayInquireRuleListResponse.go
@@ -1,0 +1,13 @@
+package responsePay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/response"
+)
+
+type AlipayInquireRuleListResponse struct {
+	response.AlipayResponse
+	Result  *model.Result        `json:"result,omitempty"`
+	HasMore bool                 `json:"hasMore,omitempty"`
+	Rules   []*model.ReserveRule `json:"rules,omitempty"`
+}

--- a/com/alipay/api/response/pay/AlipayUpdateRuleResponse.go
+++ b/com/alipay/api/response/pay/AlipayUpdateRuleResponse.go
@@ -1,0 +1,23 @@
+package responsePay
+
+import (
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/model"
+	"github.com/alipay/global-open-sdk-go/com/alipay/api/response"
+)
+
+type AlipayUpdateRuleResponse struct {
+	response.AlipayResponse
+	Result             *model.Result            `json:"result,omitempty"`
+	RuleId             string                   `json:"ruleId,omitempty"`
+	MerchantId         string                   `json:"merchantId,omitempty"`
+	FundsType          model.FundsType          `json:"fundsType,omitempty"`
+	TakeType           model.TakeType           `json:"takeType,omitempty"`
+	PaymentMethodScope model.PaymentMethodScope `json:"paymentMethodScope,omitempty"`
+	Ratio              int32                    `json:"ratio,omitempty"`
+	ReleaseType        model.ReleaseType        `json:"releaseType,omitempty"`
+	ReleaseTime        string                   `json:"releaseTime,omitempty"`
+	RetentionTime      int32                    `json:"retentionTime,omitempty"`
+	RuleStatus         model.RuleStatus         `json:"ruleStatus,omitempty"`
+	CreateTime         string                   `json:"createTime,omitempty"`
+	UpdateTime         string                   `json:"updateTime,omitempty"`
+}

--- a/com/alipay/api/sdk_version.go
+++ b/com/alipay/api/sdk_version.go
@@ -1,6 +1,6 @@
 package defaultAlipayClient
 
-const SDKVersion = "1.3.5"
+const SDKVersion = "1.3.6"
 
 func sdkUserAgent() string {
 	return "global-open-sdk-go/" + SDKVersion


### PR DESCRIPTION
- Update generated SDK models for the latest API contract.
- Add payment reserve APIs, ABA card details, Billing subscription and export fields, and Tax model changes.
- Bump the SDK release version.

Source: [OpenAPI commit](https://github.com/TeaDrinkerPlus/antom-openapi/commit/16206c9b961e58e508e0ea8398869b59df926265) and [generation diff](https://github.com/TeaDrinkerPlus/antom-adk-automation/actions/runs/32698228112).

Validation: SDK package tests, go vet, and isolated Billing consumer checks passed.