### PR TITLE
Update dispute notification fields

### DIFF
--- a/com/alipay/api/model/IssuerComments.go
+++ b/com/alipay/api/model/IssuerComments.go
@@ -1,0 +1,9 @@
+package model
+
+// IssuerComments contains issuer and cardholder comments returned in a dispute notification.
+type IssuerComments struct {
+	CardholderComments           string `json:"cardholderComments,omitempty"`
+	ReasonOfInvalidAuthorization string `json:"reasonOfInvalidAuthorization,omitempty"`
+	ExplanationOfCreditPresented string `json:"explanationOfCreditPresented,omitempty"`
+	JudgeReason                  string `json:"judgeReason,omitempty"`
+}

--- a/com/alipay/api/request/notify/AlipayDisputeNotify.go
+++ b/com/alipay/api/request/notify/AlipayDisputeNotify.go
@@ -25,4 +25,5 @@ type AlipayDisputeNotify struct {
 	CaptureId               string                        `json:"captureId,omitempty"`
 	AutoDefendReason        string                        `json:"autoDefendReason,omitempty"`
 	AcquirerInfo            *model.AcquirerInfo           `json:"acquirerInfo,omitempty"`
+	IssuerComments          *model.IssuerComments         `json:"issuerComments,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add the IssuerComments notification model
- expose issuerComments on AlipayDisputeNotify

## Validation
- SDK package tests
- dispute notification JSON deserialization smoke test