### PR TITLE
fix(meter): remove uploadEvent Go patch-version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Add the HTTP/2 session transport required by `meter/uploadEvent`.
-- `meter/uploadEvent` applications must be rebuilt with Go 1.25.13+ in the Go 1.25 series, Go 1.26.6+ in the Go 1.26 series, or a later stable Go release. Other SDK APIs remain compatible with the Go version declared in `go.mod`.
+- Allow `meter/uploadEvent` applications to use the Go version declared in `go.mod`. Production applications should use a currently supported Go release containing the latest security fixes.
 
 ## 1.2.31 - 2025-12-01
 - update 20251201

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ https://mvnrepository.com/artifact/com.alipay.global.sdk/global-open-sdk-go
 `meter/uploadEvent` with `ExecuteWithHeaders` and the returned `X-Session-Id`.
 The SDK uses the gateway URL configured on the client without sandbox path
 rewriting, request signing, response signature verification, or automatic
-retries. This API requires HTTP/2 and a binary built with Go 1.25.13+, Go
-1.26.6+, or a later stable Go release. Other SDK APIs retain the Go version
-declared in `go.mod`.
+retries. This API requires HTTP/2 and supports the Go version declared in
+`go.mod`. For production use, build applications with a currently supported
+Go release containing the latest security fixes.
 
 See `com/alipay/example/meter_upload_event_demo.go` for a complete request.
 

--- a/com/alipay/api/http2JSONTransport.go
+++ b/com/alipay/api/http2JSONTransport.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"go/version"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 	"time"
 
@@ -53,9 +51,6 @@ var sessionHTTP2Transport = &http.Transport{
 }
 
 func postHTTP2JSON(gatewayURL, path, sessionID string, requestBody []byte) ([]byte, error) {
-	if err := requireSecureHTTP2Runtime(); err != nil {
-		return nil, err
-	}
 	requestURL, err := buildSessionRequestURL(gatewayURL, path)
 	if err != nil {
 		return nil, err
@@ -89,19 +84,6 @@ func postHTTP2JSON(gatewayURL, path, sessionID string, requestBody []byte) ([]by
 		return nil, &exception.AlipayLibraryError{Message: fmt.Sprintf("response data error, HTTP status=%d, responseBody=%s", response.StatusCode, responseBody)}
 	}
 	return responseBody, nil
-}
-
-func requireSecureHTTP2Runtime() error {
-	runtimeVersion := runtime.Version()
-	if !version.IsValid(runtimeVersion) || strings.Contains(runtimeVersion, "beta") || strings.Contains(runtimeVersion, "rc") {
-		return &exception.AlipayLibraryError{Message: "this API requires an official Go release with the HTTP/2 security fix"}
-	}
-	isPatchedGo125 := version.Compare(runtimeVersion, "go1.25.13") >= 0 && version.Compare(runtimeVersion, "go1.26beta1") < 0
-	isPatchedGo126OrLater := version.Compare(runtimeVersion, "go1.26.6") >= 0
-	if !isPatchedGo125 && !isPatchedGo126OrLater {
-		return &exception.AlipayLibraryError{Message: "this API requires Go 1.25.13+, Go 1.26.6+, or a later stable release with the HTTP/2 security fix"}
-	}
-	return nil
 }
 
 func buildSessionRequestURL(gatewayURL, path string) (string, error) {

--- a/com/alipay/api/http2JSONTransport_test.go
+++ b/com/alipay/api/http2JSONTransport_test.go
@@ -1,0 +1,18 @@
+package defaultAlipayClient
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPostHTTP2JSONDoesNotRejectSupportedGoRuntime(t *testing.T) {
+	_, err := postHTTP2JSON(
+		"http://example.invalid",
+		"/ams/api/v1/meter/uploadEvent",
+		"session-id",
+		[]byte("{}"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "gatewayUrl must be an HTTPS origin") {
+		t.Fatalf("expected HTTPS origin validation error, got %v", err)
+	}
+}

--- a/com/alipay/api/request/billing/AlipayMeterUploadEventRequest.go
+++ b/com/alipay/api/request/billing/AlipayMeterUploadEventRequest.go
@@ -13,11 +13,9 @@ type AlipayMeterUploadEventRequest struct {
 // NewAlipayMeterUploadEventRequest creates a meter uploadEvent request.
 //
 // Execute this request with DefaultAlipayClient.ExecuteWithHeaders and provide
-// X-Session-Id from meter/createSession. Applications using this API must be
-// built with Go 1.25.13+ in the Go 1.25 series, Go 1.26.6+ in the Go 1.26
-// series, or a later stable Go release. This requirement applies only to
-// meter/uploadEvent; other SDK APIs remain compatible with the Go version
-// declared in go.mod.
+// X-Session-Id from meter/createSession. This API supports the Go version
+// declared in go.mod. Production applications should use a currently
+// supported Go release containing the latest security fixes.
 func NewAlipayMeterUploadEventRequest() (*request.AlipayRequest, *AlipayMeterUploadEventRequest) {
 	alipayMeterUploadEventRequest := &AlipayMeterUploadEventRequest{}
 	alipayRequest := request.NewAlipayRequest(alipayMeterUploadEventRequest, "/ams/api/v1/meter/uploadEvent", &responseBilling.AlipayMeterUploadEventResponse{})
@@ -25,7 +23,7 @@ func NewAlipayMeterUploadEventRequest() (*request.AlipayRequest, *AlipayMeterUpl
 }
 
 // NewRequest creates a meter uploadEvent request from the current parameters.
-// See NewAlipayMeterUploadEventRequest for the required Go runtime version.
+// See NewAlipayMeterUploadEventRequest for runtime guidance.
 func (alipayMeterUploadEventRequest *AlipayMeterUploadEventRequest) NewRequest() *request.AlipayRequest {
 	return request.NewAlipayRequest(&alipayMeterUploadEventRequest, "/ams/api/v1/meter/uploadEvent", &responseBilling.AlipayMeterUploadEventResponse{})
 }

--- a/com/alipay/example/meter_upload_event_demo.go
+++ b/com/alipay/example/meter_upload_event_demo.go
@@ -11,10 +11,9 @@ import (
 )
 
 // UploadMeterEvents uploads events with the session ID returned by
-// meter/createSession. Applications calling this API must be rebuilt with Go
-// 1.25.13+ in the Go 1.25 series, Go 1.26.6+ in the Go 1.26 series, or a later
-// stable Go release. Other SDK APIs can continue to use the Go version declared
-// in go.mod.
+// meter/createSession. This API supports the Go version declared in go.mod.
+// Production applications should use a currently supported Go release
+// containing the latest security fixes.
 func UploadMeterEvents(client *defaultAlipayClient.DefaultAlipayClient, sessionID string) {
 	alipayRequest, uploadRequest := billingRequest.NewAlipayMeterUploadEventRequest()
 	uploadRequest.Meters = []*model.MeterEventBatch{


### PR DESCRIPTION
## Changes
- Remove the uploadEvent runtime patch-version gate; retain strict HTTP/2 and TLS checks.
- Update runtime guidance and add a regression test. Production applications should use a supported, security-patched Go release.
- No Boolean, sessionExpiryTime, dependency or release-version changes.

## Verification
- Fetched and merged origin/master before revalidation; tested commit b253eca.
- SDK package tests and Meter example compilation pass on Go 1.22.5 and 1.26.1.
- go vet and diff checks pass.
- Live API calls were not rerun. Existing duplicate-main example issues remain outside scope.

Manual merge only.