### PR TITLE
chore(release): prepare Go SDK 1.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：GO  
 GO version：1.22.5+  
-Tags：v1.3.7
+Tags：v1.3.8
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/api/sdk_version.go
+++ b/com/alipay/api/sdk_version.go
@@ -1,6 +1,6 @@
 package defaultAlipayClient
 
-const SDKVersion = "1.3.7"
+const SDKVersion = "1.3.8"
 
 func sdkUserAgent() string {
 	return "global-open-sdk-go/" + SDKVersion


### PR DESCRIPTION
## Summary
- Bump global-open-sdk-go from 1.3.7 to 1.3.8.
- Prepare the merged Payment Hold/Release API updates for publication.

## Validation
- Post-merge release regression: Offline 18/18 and Sandbox 4/4 passed.
- SDK-scope go test and go vet passed.
- go mod verify, gofmt, and case-collision checks passed.
- Full-repository test and vet retain the existing duplicate-main failure in the example package.

## Scope
This PR changes only the SDK version source and README tag example.